### PR TITLE
allow entering other modes as a command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -53,7 +53,7 @@ end
 -- !to be deprecated! --
 
 local function define(name, help, silent)
-  return function(func)
+  return function(func, pop_first)
     xplr.fn.custom.command_mode.fn[name] = func
 
     local len = string.len(name)
@@ -61,23 +61,31 @@ local function define(name, help, silent)
       MAX_LEN = len
     end
 
-    local messages = { "PopMode" }
-
     local fn_name = "custom.command_mode.fn." .. name
 
+    local call
+
     if silent then
-      table.insert(messages, { CallLuaSilently = fn_name })
+      call = { CallLuaSilently = fn_name }
     else
-      table.insert(messages, { CallLua = fn_name })
+      call = { CallLua = fn_name }
     end
 
-	COMMANDS[name] = {
-		help = help or "",
-		fn = func,
-		-- keeping field in case there is some config that relies on it
-		silent = silent,
-		messages = messages
-	}
+    local messages
+
+	if pop_first then
+      messages = { "PopMode", call }
+    else
+      messages = { call, "PopMode" }
+    end
+
+    COMMANDS[name] = {
+      help = help or "",
+      fn = func,
+      -- keeping field in case there is some config that relies on it
+      silent = silent,
+      messages = messages
+    }
 
     return {
       cmd = COMMANDS[name],

--- a/init.lua
+++ b/init.lua
@@ -73,10 +73,16 @@ local function define(name, help, silent)
 
     local messages
 
-	if pop_first then
-      messages = { "PopMode", call }
+    if pop_first then
+      messages = {
+        { CallLuaSilently = "custom.command_mode.pop_mode" },
+        call
+      }
     else
-      messages = { call, "PopMode" }
+      messages = {
+        call,
+        { CallLuaSilently = "custom.command_mode.pop_mode" }
+      }
     end
 
     COMMANDS[name] = {
@@ -246,6 +252,8 @@ local function setup(args)
   xplr.fn.custom.command_mode = {
     map = map,
     cmd = cmd,
+	-- see https://github.com/sayanarijit/xplr/issues/755 for why this is necessary
+    pop_mode = function(_) return { "PopMode" } end,
     silent_cmd = silent_cmd,
     fn = {},
   }

--- a/init.lua
+++ b/init.lua
@@ -55,7 +55,6 @@ end
 local function define(name, help, silent)
   return function(func)
     xplr.fn.custom.command_mode.fn[name] = func
-    COMMANDS[name] = { help = help or "", fn = func, silent = silent }
 
     local len = string.len(name)
     if len > MAX_LEN then
@@ -71,6 +70,14 @@ local function define(name, help, silent)
     else
       table.insert(messages, { CallLua = fn_name })
     end
+
+	COMMANDS[name] = {
+		help = help or "",
+		fn = func,
+		-- keeping field in case there is some config that relies on it
+		silent = silent,
+		messages = messages
+	}
 
     return {
       cmd = COMMANDS[name],
@@ -180,8 +187,7 @@ local function setup(args)
         enter = {
           help = "execute",
           messages = {
-            { CallLuaSilently = "custom.command_mode.execute" },
-            "PopMode",
+            { CallLuaSilently = "custom.command_mode.execute" }
           },
         },
         esc = {
@@ -246,13 +252,7 @@ local function setup(args)
           CURR_CMD_INDEX = CURR_CMD_INDEX + 1
         end
 
-        if command.silent then
-          return command.fn(app)
-        else
-          return {
-            { CallLua = "custom.command_mode.fn." .. name },
-          }
-        end
+        return command.messages
       end
     end
   end


### PR DESCRIPTION
Fixes pop order issue.

Unfortunately, there is now a flicker between command mode and some commands.  I'm not certain why.  May be related to https://github.com/sayanarijit/xplr/issues/755?

Also added a boolean to change the behavior to pop first v. pop after.